### PR TITLE
Changes to allow larger value types, and a larger number of nodes.

### DIFF
--- a/boost/btree/detail/binary_file.hpp
+++ b/boost/btree/detail/binary_file.hpp
@@ -84,6 +84,25 @@ namespace boost
       static const handle_type invalid_handle = -1;
 #    endif
 
+      class open_transaction
+      {
+      public:
+        open_transaction()
+          : m_file(0) {}
+
+       ~open_transaction()
+	   {
+		 if (m_file)
+			 m_file->close();
+	   }
+
+        void commit()  { m_file = 0; }
+
+      private:
+        binary_file* m_file;
+
+        friend class binary_file;
+      };
  
       binary_file()
         : m_handle(invalid_handle) {}
@@ -101,6 +120,8 @@ namespace boost
       bool open(const filesystem::path& p, oflag::bitmask flags, system::error_code& ec);
       // Requires: !is_open()
       // Returns: true if successful.
+
+      void file_open_transaction(open_transaction& transaction)  { transaction.m_file = this; }
 
       void close();
       bool close(system::error_code& ec);

--- a/boost/btree/detail/binary_file.hpp
+++ b/boost/btree/detail/binary_file.hpp
@@ -24,7 +24,7 @@
 #define BOOST_BINARY_FILE_HPP
 
 #include <boost/btree/detail/config.hpp>
-#include <boost/filesystem/v3/path.hpp>
+#include <boost/filesystem/path.hpp>
 #include <boost/detail/bitmask.hpp>
 #include <boost/assert.hpp>
 #include <ios>

--- a/boost/btree/detail/buffer_manager.hpp
+++ b/boost/btree/detail/buffer_manager.hpp
@@ -253,8 +253,8 @@ namespace boost
       boost::uint32_t  file_buffers_written() const {return m_file_buffers_written;}
       boost::uint32_t  new_buffer_requests() const  {return m_new_buffer_requests;}
       boost::uint32_t  buffer_allocs() const        {return m_buffer_allocs;}
-      boost::uint32_t  buffers_in_memory() const    {return buffers.size();}
-      boost::uint32_t  buffers_available() const    {return buffer_cache.size();}
+      boost::uint32_t  buffers_in_memory() const    {return static_cast<boost::uint32_t>(buffers.size());}
+      boost::uint32_t  buffers_available() const    {return static_cast<boost::uint32_t>(buffer_cache.size());}
 
 #ifndef BOOST_BUFFER_MANAGER_TEST
     private:

--- a/boost/btree/detail/common.hpp
+++ b/boost/btree/detail/common.hpp
@@ -1075,6 +1075,10 @@ btree_base<Key,Base,Traits,Comp>::m_open(const boost::filesystem::path& p,
       BOOST_BTREE_THROW(std::runtime_error(file_path().string()+" isn't a btree"));
     if (m_hdr.big_endian() != (Traits::header_endianness == integer::endianness::big))
       BOOST_BTREE_THROW(std::runtime_error(file_path().string()+" has wrong endianness"));
+	if (m_hdr.key_size() != Base::key_size())
+      BOOST_BTREE_THROW(std::runtime_error(file_path().string()+" has wrong key size"));
+	if (m_hdr.mapped_size() != Base::mapped_size())
+      BOOST_BTREE_THROW(std::runtime_error(file_path().string()+" has wrong mapped size"));
     m_mgr.data_size(m_hdr.node_size());
     m_root = m_mgr.read(m_hdr.root_node_id());
   }

--- a/boost/btree/detail/common.hpp
+++ b/boost/btree/detail/common.hpp
@@ -726,7 +726,7 @@ private:
     bool               is_leaf() const       {return leaf().is_leaf();}
     bool               is_branch() const     {return leaf().is_branch();}
     std::size_t        size() const          {return leaf().m_size;}  // std::size_t is correct!
-    void               size(std::size_t sz)  {leaf().m_size = sz;}    // ditto
+    void               size(std::size_t sz)  {leaf().m_size = static_cast<unsigned int>(sz);}    // ditto
     bool               empty() const         {return leaf().m_size == 0;}
 
     btree_node_ptr     next_node()  // return next node at current level

--- a/boost/btree/detail/common.hpp
+++ b/boost/btree/detail/common.hpp
@@ -1070,6 +1070,8 @@ btree_base<Key,Base,Traits,Comp>::m_open(const boost::filesystem::path& p,
 
   if (m_mgr.open(p, open_flags, btree::default_max_cache_nodes, node_sz))
   { // existing non-truncated file
+	binary_file::open_transaction open_transaction;
+	m_mgr.file_open_transaction(open_transaction);
     m_read_header();
     if (!m_hdr.marker_ok())
       BOOST_BTREE_THROW(std::runtime_error(file_path().string()+" isn't a btree"));
@@ -1081,6 +1083,7 @@ btree_base<Key,Base,Traits,Comp>::m_open(const boost::filesystem::path& p,
       BOOST_BTREE_THROW(std::runtime_error(file_path().string()+" has wrong mapped size"));
     m_mgr.data_size(m_hdr.node_size());
     m_root = m_mgr.read(m_hdr.root_node_id());
+	open_transaction.commit();
   }
   else
   { // new or truncated file

--- a/boost/btree/detail/common.hpp
+++ b/boost/btree/detail/common.hpp
@@ -163,8 +163,8 @@ public:
 
   const Key& key(const value_type& v) const {return v;}  // really handy, so expose
 
-  static std::size_t key_size() { return -1; }
-  static std::size_t mapped_size() { return -1; }
+  static std::size_t key_size() { return sizeof(Key); }
+  static std::size_t mapped_size() { return sizeof(Key); }
 
 protected:
   void m_memcpy_value(value_type* dest, const Key* k, std::size_t key_sz,
@@ -188,8 +188,8 @@ public:
   const Key& key(const value_type& v) const  // really handy, so expose
     {return v.key();}
 
-  static std::size_t key_size() { return -1; }
-  static std::size_t mapped_size() { return -1; }
+  static std::size_t key_size() { return sizeof(Key); }
+  static std::size_t mapped_size() { return sizeof(T); }
 
   class value_compare
   {

--- a/boost/btree/header.hpp
+++ b/boost/btree/header.hpp
@@ -101,7 +101,7 @@ namespace boost
 
       BOOST_BITMASK(bitmask);
 
-      bitmask user(bitmask m) {return m & (read_write|truncate|preload); }
+      inline bitmask user(bitmask m) {return m & (read_write|truncate|preload); }
     }
 
     static const boost::uint8_t major_version = 0;  // version identification

--- a/boost/btree/header.hpp
+++ b/boost/btree/header.hpp
@@ -41,7 +41,7 @@ namespace boost
     struct default_native_traits
     {
       typedef boost::uint32_t  node_id_type;     // node ids
-      typedef boost::uint16_t  node_size_type;   // sizes
+      typedef boost::uint32_t  node_size_type;   // sizes
       typedef boost::uint16_t  node_level_type;  // level of node; 0 for leaf node.
                                                  // Could be smaller, but that would
                                                  // require alignment byte so why bother
@@ -56,7 +56,7 @@ namespace boost
     struct default_big_endian_traits
     {
       typedef integer::ubig32_t  node_id_type;
-      typedef integer::ubig16_t  node_size_type;
+      typedef integer::ubig32_t  node_size_type;
       typedef integer::ubig16_t  node_level_type;
       static const BOOST_SCOPED_ENUM(integer::endianness) header_endianness
         = integer::endianness::big;
@@ -65,7 +65,7 @@ namespace boost
     struct default_little_endian_traits
     {
       typedef integer::ulittle32_t  node_id_type;
-      typedef integer::ulittle16_t  node_size_type;
+      typedef integer::ulittle32_t  node_size_type;
       typedef integer::ulittle16_t  node_level_type;
       static const BOOST_SCOPED_ENUM(integer::endianness) header_endianness
         = integer::endianness::little;
@@ -74,7 +74,7 @@ namespace boost
     struct default_endian_traits
     {
       typedef integer::ubig32_t  node_id_type;
-      typedef integer::ubig16_t  node_size_type;
+      typedef integer::ubig32_t  node_size_type;
       typedef integer::ubig16_t  node_level_type;
       static const BOOST_SCOPED_ENUM(integer::endianness) header_endianness
         = integer::endianness::big;
@@ -143,8 +143,8 @@ namespace boost
       node_id_type        m_free_node_list_head_id;  // list of recycleable nodes
 
       boost::uint16_t     m_root_level;
-      boost::uint16_t     m_key_size;            // sizeof(key_type); -1 imples indirect
-      boost::uint16_t     m_mapped_size;         // sizeof(mapped_type); -1 implies indirect
+      boost::uint32_t     m_key_size;            // sizeof(key_type); -1 imples indirect
+      boost::uint32_t     m_mapped_size;         // sizeof(mapped_type); -1 implies indirect
 
       // TODO: Add a better way to verify that an existing file is opened using the same
       // Key, T, Comp, and Traits or when originally created. 
@@ -172,8 +172,8 @@ namespace boost
       boost::uint8_t   major_version() const         { return m_major_version; }  
       boost::uint8_t   minor_version() const         { return m_minor_version; }  
       boost::uint32_t  node_size() const             { return m_node_size; }
-      boost::uint16_t  key_size() const              { return m_key_size; }
-      boost::uint16_t  mapped_size() const           { return m_mapped_size; }
+      boost::uint32_t  key_size() const              { return m_key_size; }
+      boost::uint32_t  mapped_size() const           { return m_mapped_size; }
       flags::bitmask   flags() const { return static_cast<flags::bitmask>(m_flags); }
 
       //  "updated" members that change as the file changes

--- a/boost/btree/header.hpp
+++ b/boost/btree/header.hpp
@@ -202,9 +202,9 @@ namespace boost
       }
       void  major_version(boost::uint8_t value)      { m_major_version = value; } 
       void  minor_version(boost::uint8_t value)      { m_minor_version = value; }  
-      void  node_size(std::size_t sz)                { m_node_size = sz; }
-      void  key_size(std::size_t sz)                 { m_key_size = sz; }
-      void  mapped_size(std::size_t sz)              { m_mapped_size = sz; }
+      void  node_size(std::size_t sz)                { m_node_size = static_cast<uint32_t>(sz); }
+      void  key_size(std::size_t sz)                 { m_key_size = static_cast<uint32_t>(sz); }
+      void  mapped_size(std::size_t sz)              { m_mapped_size = static_cast<uint32_t>(sz); }
       void  flags(flags::bitmask flgs)               { m_flags = flgs; }
       void  element_count(boost::uint64_t value)     { m_element_count = value; }
       void  increment_element_count()                { ++m_element_count; }


### PR DESCRIPTION
Hi, Beman.  It's Zach Laine from BoostCon.  I have been getting great use out of Boost.Btree at my new job.  I'm using it to page large quantities of terrain for a 3D terrain renderer.  I've made some modifications to Boost.Btree in the process.  The commits are intentionally made in least- to most-controversial order (for example, the first one fixes a link error).

The overall nature of the changes was to allow the representation of larger value types which are well over 64kb (e.g. 512x512 tiles of 3-byte pixels).  Whereas Boost.Btree seems to be oriented around large collections of small values, we have need for large collections or large values.

Also, there is a commit in there that throw when you attempt to load from a btree whose value and/or mapped types are not the size you expect.  I needed this in order to make it easier to work with data at multiple levels of detail (LOD).  I may represent the same geographical region with a 512x512 tile, a 256x256 tile, a 128x128 tile, etc.  Being able to rely on an exception being thrown when I tried to load the wrong size tile was very useful.

The last commit does rollback on an open() when the exception above is thrown.  This also made my particular case easier to manage.

I hope you'll accept all these changes, but will understand if you don't.  The most critical ones for my use case are the ones at or before c9566b1c2db9b37a2c885a3a7d216775cc76a529.

Thanks in advance,

Zach
